### PR TITLE
Add migration to grant UPDATE permissions to rear_diff user on atp.me…

### DIFF
--- a/migrations/V14__grant_rear_diff_media_update_columns.sql
+++ b/migrations/V14__grant_rear_diff_media_update_columns.sql
@@ -1,0 +1,3 @@
+-- Grant UPDATE permission on specific columns of atp.media table to rear_diff user
+GRANT UPDATE (pipeline_status, error_status, error_condition, rejection_status, rejection_reason) 
+ON atp.media TO rear_diff;


### PR DESCRIPTION
…dia columns

Grants UPDATE permissions on pipeline_status, error_status, error_condition, rejection_status, and rejection_reason columns to rear_diff user.

🤖 Generated with [Claude Code](https://claude.ai/code)